### PR TITLE
Fix UNC path handling and minimized windows in WindowsExplorerAction

### DIFF
--- a/streamdeck-wintools/Actions/WindowsExplorerAction.cs
+++ b/streamdeck-wintools/Actions/WindowsExplorerAction.cs
@@ -264,11 +264,11 @@ namespace WinTools
 
                             if (String.IsNullOrWhiteSpace(settings.Encoding))
                             {
-                                return Uri.UnescapeDataString(uri.AbsoluteUri.LocalPath);
+                                return Uri.UnescapeDataString(uri.LocalPath);
                             }
 
                             Encoding e = Encoding.GetEncoding(settings.Encoding);
-                            return System.Web.HttpUtility.UrlDecode(uri.AbsoluteUri.LocalPath, e);
+                            return System.Web.HttpUtility.UrlDecode(uri.LocalPath, e);
                         }
                     }
                     catch (Exception ex)
@@ -314,7 +314,7 @@ namespace WinTools
                     {
                         // Save the location off to your application
                         Uri uri = new Uri(ie.LocationURL);
-                        string currentPath = Uri.UnescapeDataString(uri.AbsoluteUri.LocalPath);
+                        string currentPath = Uri.UnescapeDataString(uri.LocalPath);
                         if (currentPath.ToLowerInvariant() == explorerPath.ToLowerInvariant())
                         {
                             IntPtr destinationProcess = new IntPtr(ie.HWND);

--- a/streamdeck-wintools/Actions/WindowsExplorerAction.cs
+++ b/streamdeck-wintools/Actions/WindowsExplorerAction.cs
@@ -264,11 +264,11 @@ namespace WinTools
 
                             if (String.IsNullOrWhiteSpace(settings.Encoding))
                             {
-                                return Uri.UnescapeDataString(uri.AbsolutePath);
+                                return Uri.UnescapeDataString(uri.AbsoluteUri.LocalPath);
                             }
 
                             Encoding e = Encoding.GetEncoding(settings.Encoding);
-                            return System.Web.HttpUtility.UrlDecode(uri.AbsolutePath, e);
+                            return System.Web.HttpUtility.UrlDecode(uri.AbsoluteUri.LocalPath, e);
                         }
                     }
                     catch (Exception ex)
@@ -314,7 +314,7 @@ namespace WinTools
                     {
                         // Save the location off to your application
                         Uri uri = new Uri(ie.LocationURL);
-                        string currentPath = Uri.UnescapeDataString(uri.AbsolutePath);
+                        string currentPath = Uri.UnescapeDataString(uri.AbsoluteUri.LocalPath);
                         if (currentPath.ToLowerInvariant() == explorerPath.ToLowerInvariant())
                         {
                             IntPtr destinationProcess = new IntPtr(ie.HWND);

--- a/streamdeck-wintools/Actions/WindowsExplorerAction.cs
+++ b/streamdeck-wintools/Actions/WindowsExplorerAction.cs
@@ -318,7 +318,7 @@ namespace WinTools
                         if (currentPath.ToLowerInvariant() == explorerPath.ToLowerInvariant())
                         {
                             IntPtr destinationProcess = new IntPtr(ie.HWND);
-                            if (SetForegroundWindow(destinationProcess))
+                            if (ShowWindow(destinationProcess, ShowWindowEnum.RESTORE) && SetForegroundWindow(destinationProcess))
                             {
                                 Logger.Instance.LogMessage(TracingLevel.INFO, $"Successfully set foreground window for Explorer with path {currentPath} HWND: {ie.HWND}");
                                 return true;

--- a/streamdeck-wintools/Backend/ForceForegroundSettings.cs
+++ b/streamdeck-wintools/Backend/ForceForegroundSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -19,5 +20,17 @@ namespace WinTools.Backend
         SHOWNA = 8,
         RESTORE = 9,
         SHOWDEFAULT = 10
+    }
+    
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct WindowPlacement
+    {
+        public int Length;
+        public int Flags;
+        public ShowWindowEnum ShowCmd;
+        public System.Drawing.Point MinPosition;
+        public System.Drawing.Point MaxPosition;
+        public System.Drawing.Rectangle NormalPosition;
     }
 }


### PR DESCRIPTION
Here are fixes for two major bugs in `WindowsExplorerAction`:

###  UNC paths (for network file shares) do not work.

`LocalPath` should be used in place of `AbsolutePath`. They function identically for local files, but `LocalPath` provides a proper path for network file shares.
```cs
new Uri("file:////C:/test/../path").AbsolutePath   -> @"C:\path"
new Uri("file://server/test/../path").AbsolutePath -> @"/path"
new Uri("file:////C:/test/../path").LocalPath      -> @"C:\path"
new Uri("file://server/test/../path").LocalPath    -> @"\\server\path"
```

### Minimized windows do not get restored when brought to the foreground.

This bug and its fix are demonstrated in this StackOverflow post: https://stackoverflow.com/questions/27449298/setforegroundwindow-doesnt-work-with-minimized-process